### PR TITLE
Fix centos8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,12 +8,16 @@ pipeline {
       script: 'curl -s http://mirror.centos.org/centos/7/isos/x86_64/sha256sum.txt | sed -n "s/^.*\\(CentOS-7-x86_64-Minimal-[0-9]\\+\\)\\.iso.*$/\\1/p"',
       returnStdout: true
     ).trim()
+    CENTOS8_VERSION = sh(
+      script: 'curl -s http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CHECKSUM | sed -n "1s/^.*\(CentOS-Stream-8-x86_64-[0-9]\+\)\-boot.iso.*$/\1/p"',
+      returnStdout: true
+    ).trim()
   }
 
   stages {
     stage('Build images') {
       steps {
-        sh "packer build -var centos7_image=${CENTOS7_VERSION} build-cloudimg.json"
+        sh "packer build -var centos7_image=${CENTOS7_VERSION} -var centos8_image=${CENTOS8_VERSION} build-cloudimg.json"
       }
       post {
         success {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Execute the following command to build your image.
 
     packer build \
       -var centos7_image=$(curl -s http://mirror.centos.org/centos/7/isos/x86_64/sha256sum.txt | sed -n "s/^.*\(CentOS-7-x86_64-Minimal-[0-9]\+\)\.iso.*$/\1/p") \
+      -var centos8_image=$(curl -s http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CHECKSUM | sed -n "1s/^.*\(CentOS-Stream-8-x86_64-[0-9]\+\)\-boot.iso.*$/\1/p") \
       build-cloudimg.json
 
 The image will be located in **build** directory.

--- a/build-cloudimg.json
+++ b/build-cloudimg.json
@@ -1,6 +1,7 @@
 {
   "variables": {
-    "centos7_image": ""
+    "centos7_image": "",
+    "centos8_image": ""
   },
   "builders": [
     {
@@ -34,7 +35,7 @@
     },
     {
       "type": "qemu",
-      "iso_url": "http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CentOS-Stream-x86_64-boot.iso",
+      "iso_url": "http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/C{{user `centos8_image`}}-boot.iso",
       "iso_checksum_url": "http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CHECKSUM",
       "iso_checksum_type": "sha256",
       "output_directory": "build",


### PR DESCRIPTION
CentOS does no longer provide a "latest" .iso file. This PR fetches the latest image that exists in the checksum file provided by the mirror