### PR TITLE
Add local testing support for CentOS images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,27 @@ PACKER_INSTALLED_VERSION := $(shell ./packer --version)
 CENTOS7_IMAGE=$(shell curl -s http://mirror.nsc.liu.se/centos/7/isos/x86_64/sha256sum.txt | sed -n "s/^.*\(CentOS-7-x86_64-Minimal-[0-9]\+\.iso\).*$$/\1/p")
 CENTOS8_IMAGE=$(shell curl -s http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CHECKSUM | sed -n "s/^SHA256 (\(CentOS-Stream-8-x86_64-[0-9]\+-boot\.iso\)).*$$/\1/p")
 
+ifeq ($(shell uname),Linux)
+ACCEL ?= "kvm"
+else ifeq ($(shell uname),Darwin)
+ACCEL ?= "hvf"
+else
+ACCEL ?= "tcg"
+endif
 
-default: clean prepare build 
 
+.PHONY: default
+default: clean prepare build
+
+.PHONY: clean
 clean:
 	rm -rf images
 
+.PHONY: clean-cache
 clean-cache:
 	rm -rf packer_cache
 
+.PHONY: prepare
 prepare:
 ifneq (${PACKER_INSTALLED_VERSION},${PACKER_VERSION})
 	curl -o ${PACKER_BIN} -fSL "${PACKER_DOWNLOAD_BASE_URL}/${PACKER_BIN}"
@@ -27,7 +39,35 @@ ifneq (${PACKER_INSTALLED_VERSION},${PACKER_VERSION})
 	rm -f ${PACKER_BIN} ${PACKER_CHECKSUM}
 endif
 
+.PHONY: build
 build:
-	./packer build -var centos7_image=${CENTOS7_IMAGE} -var centos8_image=${CENTOS8_IMAGE} build-cloudimg.json
+	./packer build \
+		-var centos7_image=${CENTOS7_IMAGE} \
+		-var centos8_image=${CENTOS8_IMAGE} \
+		build-cloudimg.json
 
+images/%-test.img: images/%
+	qemu-img create -f qcow2 \
+		-o backing_file="$(shell basename $<)" "$@"
+
+images/cloudconfig-test.img: test/user-data test/meta-data
+	truncate -s 2M "$@"
+	mkfs.vfat -n cidata "$@"
+	mcopy -oi "$@" $^ ::
+	mdir -i "$@" ::
+
+run-%: images/%-latest-test.img images/cloudconfig-test.img
+	qemu-system-x86_64 \
+		-m 512 \
+		-drive file="$<",if=virtio,format=qcow2 \
+		-drive file=images/cloudconfig-test.img,if=virtio,format=raw \
+		-device virtio-net-pci,romfile=,netdev=net0 \
+		-netdev user,hostfwd=tcp::5555-:22,id=net0 \
+		-accel "$(ACCEL)" \
+		-machine type=q35,smm=on,usb=on \
+		-serial mon:stdio \
+		-no-reboot \
+		-nographic \
+
+.PHONY: all
 all: clean clean-cache prepare build

--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ Execute the following command to build your image.
       -var centos7_image=$(curl -s http://mirror.nsc.liu.se/centos/7/isos/x86_64/sha256sum.txt | sed -n "s/^.*\(CentOS-7-x86_64-Minimal-[0-9]\+\.iso\).*$/\1/p") \
       -var centos8_image=$(curl -s http://mirror.nsc.liu.se/CentOS/8-stream/isos/x86_64/CHECKSUM | sed -n "s/^SHA256 (\(CentOS-Stream-8-x86_64-[0-9]\+-boot\.iso\)).*$/\1/p")
       build-cloudimg.json
+
+## Testing the image
+
+If you want to run the image locally, you can do so by running
+`make run-centos-7`.
+
+> 💡 **Tip:** You can exit out of QEMU using `Ctrl+a + x`.
+You might need to run `stty sane` afterwards if you exited QEMU in a state
+where the terminal was set up in a funny way.
+
+The make command will create a cloud-init configuration bundle using
+VFAT which the machine will then pick up. The built image is mounted as
+copy-on-write, if you want to reset your test environment you can do so by
+executing `rm -iv images/*-test.img`.
+
+The username / password is set to be `centos` / `centos` in the test
+environment. It will have internet access, and you can SSH into the instance
+by running `ssh -o StrictHostKeyChecking=no -p 5555 localhost -l centos`.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ executing `rm -iv images/*-test.img`.
 
 The username / password is set to be `centos` / `centos` in the test
 environment. It will have internet access, and you can SSH into the instance
-by running `ssh -o StrictHostKeyChecking=no -p 5555 localhost -l centos`.
+by running `ssh -o NoHostAuthenticationForLocalhost=yes -p 5555 localhost -l centos`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This git repo contain Packer and kickstart files to define and build CentOS clou
 ## Prerequisites
 These prerequisites are written for Ubuntu 20.04.
 
-1. `qemu-system-x86`, `qemu-utils` and a working installation of [Packer](https://www.packer.io/). Tested version is **v1.6.2**.
+1. `qemu-system-x86`, `qemu-utils` and a working installation of [Packer](https://www.packer.io/). Tested version is **v1.7.2**.
 
 2. `curl` and `sed` already installed on your system if you want to dynamically build from latest rolling upgrade release.
+
+3. For testing you also need `mtools`.
 
 ## Building the image
 

--- a/test/user-data
+++ b/test/user-data
@@ -1,0 +1,9 @@
+#cloud-config
+
+users:
+- name: centos
+  lock-passwd: false
+  groups: wheel
+  # Password is 'centos'
+  passwd: $6$JyHlhupoD9$4tLYQCdIqaN1bBOpN95r7US/.dYsYk4/twEpeaPeZWvs48l.etcn4y828BaPpM/FrZv5y63josa0VwU3xhj2G/
+ssh_pwauth: True


### PR DESCRIPTION
This commit adds helper systems to allow easily booting a built image to
verify functionallity or debug behavior. It aims to be close to what the
environment will be like in OpenStack.

Depends on #2 (by order, not by features)