### PR TITLE
Mitigate CVE-2021-20271 for CentOS 8

### DIFF
--- a/httpdir/centos-8-ext4.ks
+++ b/httpdir/centos-8-ext4.ks
@@ -119,6 +119,9 @@ echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 echo -e 'centos\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 sed -i 's/name: cloud-user/name: centos/g' /etc/cloud/cloud.cfg
 
+# Mitigate CVE-2021-20271 (https://github.com/elastx/team-infra/issues/175)
+echo '%_pkgverify_level all' > /etc/rpm/macros
+
 echo "Cleaning old yum repodata."
 dnf clean all
 


### PR DESCRIPTION
Enable full RPM signature verification.

Partial fix for elastx/team-infra#175

Test:
```
[centos@localhost ~]$  rpm --eval "%_pkgverify_level"
all
[centos@localhost ~]$ sudo dnf install vim
Warning: Enforcing GPG signature check globally as per active RPM security policy (see 'gpgcheck' in dnf.conf(5) for how to squelch this message)
Last metadata expiration check: 0:00:42 ago on Wed 05 May 2021 01:36:03 PM UTC.
Dependencies resolved.
================================================================================
 Package             Arch        Version                   Repository      Size
================================================================================
Installing:
 vim-enhanced        x86_64      2:8.0.1763-15.el8         appstream      1.4 M
Installing dependencies:
 gpm-libs            x86_64      1.20.7-15.el8             appstream       39 k
 vim-common          x86_64      2:8.0.1763-15.el8         appstream      6.3 M
 vim-filesystem      noarch      2:8.0.1763-15.el8         appstream       48 k

Transaction Summary
================================================================================
Install  4 Packages

Total download size: 7.8 M
Installed size: 30 M
Is this ok [y/N]: y
Downloading Packages:
(1/4): gpm-libs-1.20.7-15.el8.x86_64.rpm        462 kB/s |  39 kB     00:00    
(2/4): vim-filesystem-8.0.1763-15.el8.noarch.rp 1.9 MB/s |  48 kB     00:00    
(3/4): vim-enhanced-8.0.1763-15.el8.x86_64.rpm  3.4 MB/s | 1.4 MB     00:00    
(4/4): vim-common-8.0.1763-15.el8.x86_64.rpm    5.7 MB/s | 6.3 MB     00:01    
--------------------------------------------------------------------------------
Total                                           6.3 MB/s | 7.8 MB     00:01     
warning: /var/cache/dnf/appstream-a3ce6348fe6cbd6c/packages/gpm-libs-1.20.7-15.el8.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 8483c65d: NOKEY
CentOS Linux 8 - AppStream                      1.6 MB/s | 1.6 kB     00:00    
Importing GPG key 0x8483C65D:
 Userid     : "CentOS (CentOS Official Signing Key) <security@centos.org>"
 Fingerprint: 99DB 70FA E1D7 CE22 7FB6 4882 05B5 55B3 8483 C65D
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Is this ok [y/N]: y
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : vim-filesystem-2:8.0.1763-15.el8.noarch                1/4 
  Installing       : vim-common-2:8.0.1763-15.el8.x86_64                    2/4 
  Installing       : gpm-libs-1.20.7-15.el8.x86_64                          3/4 
  Running scriptlet: gpm-libs-1.20.7-15.el8.x86_64                          3/4 
  Installing       : vim-enhanced-2:8.0.1763-15.el8.x86_64                  4/4 
  Running scriptlet: vim-enhanced-2:8.0.1763-15.el8.x86_64                  4/4 
  Running scriptlet: vim-common-2:8.0.1763-15.el8.x86_64                    4/4 
  Verifying        : gpm-libs-1.20.7-15.el8.x86_64                          1/4 
  Verifying        : vim-common-2:8.0.1763-15.el8.x86_64                    2/4 
  Verifying        : vim-enhanced-2:8.0.1763-15.el8.x86_64                  3/4 
  Verifying        : vim-filesystem-2:8.0.1763-15.el8.noarch                4/4 

Installed:
  gpm-libs-1.20.7-15.el8.x86_64         vim-common-2:8.0.1763-15.el8.x86_64    
  vim-enhanced-2:8.0.1763-15.el8.x86_64 vim-filesystem-2:8.0.1763-15.el8.noarch

Complete!
[centos@localhost ~]$ 
```